### PR TITLE
Fix function names, parameters, and equality op

### DIFF
--- a/grammars/oz.cson
+++ b/grammars/oz.cson
@@ -15,11 +15,11 @@
     'name': 'comment.block.documentation.oz'
   }
   {
-    'match': '\\b(andthen|at|attr|case|catch|class|choice|cond|declare|define|do|dis|else|elsecase|elseif|end|export|feat|finally|for|from|fun|functor|if|in|import|lex|local|lock|meth|mode|not|of|or|orelse|parser|prepare|proc|prod|prop|raise|require|scanner|skip|suchthat|syn|then|thread|token|try)\\b|^\\s*\\[\\]'
+    'match': '\\b(andthen|at|attr|case|catch|class|choice|cond|declare|define|do|dis|else|elsecase|elseif|end|export|feat|finally|for|from|functor|if|in|import|lex|local|lock|meth|mode|not|of|or|orelse|parser|prepare|prod|prop|raise|require|scanner|skip|suchthat|syn|then|thread|token|try)\\b|^\\s*\\[\\]'
     'name': 'keyword.control.oz'
   }
   {
-    'match': '=|:='
+    'match': '=(?!=)|:='
     'name': 'keyword.operator.assignement.oz'
   }
   {
@@ -50,7 +50,7 @@
         'name': 'entity.name.function.oz'
       '3':
         'name': 'variable.parameter.function.oz'
-    'match': '\\b(fun|proc)\\b\\s+\\{(\\w+)((?:\\s\\w+)*)\\}'
+    'match': '\\b(fun|proc)\\s+\\{(\\w+)(?:\\s+((\\w+|\\s+\\w+)*))\\}'
     'name': 'meta.function.oz'
   }
   {


### PR DESCRIPTION
Function match wasn't working, parameters would only catch last parameter, and equality operator was being pre-empted by assignment rule.
